### PR TITLE
feat: implement limit-connection-reuses

### DIFF
--- a/quics-client/Cargo.toml
+++ b/quics-client/Cargo.toml
@@ -4,8 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["trace", "aws-lc-rs"]
+default = ["trace", "aws-lc-rs", "limit-connection-reuses"]
 trace = ["tracing", "tracing-subscriber"]
+limit-connection-reuses = []
 
 [dependencies]
 quics-protocol = { path = "../quics-protocol"}


### PR DESCRIPTION
The limit-connection-reuses feature, which controls the number of times each QUIC Client connection can reuse streams. This enhancement helps manage connection efficiency and resource usage, improving overall performance

close #3 